### PR TITLE
Allow vouchers listing with no params and enable force param for product

### DIFF
--- a/lib/voucherify/service/products.rb
+++ b/lib/voucherify/service/products.rb
@@ -21,8 +21,8 @@ module Voucherify
         @client.put("/products/#{URI.encode(product['id'] || product[:id])}", product.to_json)
       end
 
-      def delete(product_id)
-        @client.delete("/products/#{URI.encode(product_id)}")
+      def delete(product_id, params = {})
+        @client.delete("/products/#{URI.encode(product_id)}", {:force => (!!(params['force'] || params[:force])).to_s})
       end
 
       def list(query = {})

--- a/lib/voucherify/service/vouchers.rb
+++ b/lib/voucherify/service/vouchers.rb
@@ -23,7 +23,7 @@ module Voucherify
         @client.put("/vouchers/#{URI.encode(voucher_update['code'] || voucher_update[:code])}", voucher_update.to_json)
       end
 
-      def list(query)
+      def list(query=nil)
         @client.get('/vouchers', query)
       end
 


### PR DESCRIPTION
Sometimes we don't need to specify any params for listing vouchers, which leads to an error. This fixes this scenario. 

Also, it allows to permanently delete a product by specifying `force: true`