### PR TITLE
replaced calls to the deprecated URI.encode with ERB::Util.url_encode

### DIFF
--- a/lib/voucherify/service/campaigns.rb
+++ b/lib/voucherify/service/campaigns.rb
@@ -14,25 +14,25 @@ module Voucherify
       end
 
       def get(campaign_name)
-        @client.get("/campaigns/#{URI.encode(campaign_name)}")
+        @client.get("/campaigns/#{ERB::Util.url_encode(campaign_name)}")
       end
 
       def delete(campaign_name, params = {})
-        @client.delete("/campaigns/#{URI.encode(campaign_name)}", {:force => (!!(params['force'] || params[:force])).to_s})
+        @client.delete("/campaigns/#{ERB::Util.url_encode(campaign_name)}", {:force => (!!(params['force'] || params[:force])).to_s})
         nil
       end
 
       def add_voucher(campaign_name, params = {})
         code = params['code'] || params[:code]
-        url = "/campaigns/#{URI.encode(campaign_name)}/vouchers"
-        url += "/#{URI.encode(code)}" if code
+        url = "/campaigns/#{ERB::Util.url_encode(campaign_name)}/vouchers"
+        url += "/#{ERB::Util.url_encode(code)}" if code
         params.delete 'code'
         params.delete :code
         @client.post(url, params.to_json)
       end
 
       def import_vouchers(campaign_name, vouchers)
-        @client.post("/campaigns/#{URI.encode(campaign_name)}/import", vouchers.to_json)
+        @client.post("/campaigns/#{ERB::Util.url_encode(campaign_name)}/import", vouchers.to_json)
       end
     end
   end

--- a/lib/voucherify/service/customers.rb
+++ b/lib/voucherify/service/customers.rb
@@ -18,15 +18,15 @@ module Voucherify
       end
 
       def get(customer_id)
-        @client.get("/customers/#{URI.encode(customer_id)}")
+        @client.get("/customers/#{ERB::Util.url_encode(customer_id)}")
       end
 
       def update(customer)
-        @client.put("/customers/#{URI.encode(customer['id'] || customer[:id])}", customer.to_json)
+        @client.put("/customers/#{ERB::Util.url_encode(customer['id'] || customer[:id])}", customer.to_json)
       end
 
       def delete(customer_id)
-        @client.delete("/customers/#{URI.encode(customer_id)}")
+        @client.delete("/customers/#{ERB::Util.url_encode(customer_id)}")
       end
     end
   end

--- a/lib/voucherify/service/distributions.rb
+++ b/lib/voucherify/service/distributions.rb
@@ -25,11 +25,11 @@ module Voucherify
       end
 
       def get_export(id)
-        @client.get("/exports/#{URI.encode(id)}")
+        @client.get("/exports/#{ERB::Util.url_encode(id)}")
       end
 
       def delete_export(id)
-        @client.delete("/exports/#{URI.encode(id)}")
+        @client.delete("/exports/#{ERB::Util.url_encode(id)}")
       end
 
       def list_publications(params = {})
@@ -39,7 +39,7 @@ module Voucherify
       def create_publication(params)
         @client.post('/publications', params.to_json)
       end
-      
+
     end
   end
 end

--- a/lib/voucherify/service/loyalties.rb
+++ b/lib/voucherify/service/loyalties.rb
@@ -30,15 +30,15 @@ module Voucherify
       end
 
       def update(loyalty_id, loyalty)
-        @client.put("/loyalties/#{URI.encode(loyalty_id)}", loyalty.to_json)
+        @client.put("/loyalties/#{ERB::Util.url_encode(loyalty_id)}", loyalty.to_json)
       end
 
       def get(loyalty_id)
-        @client.get("/loyalties/#{URI.encode(loyalty_id)}")
+        @client.get("/loyalties/#{ERB::Util.url_encode(loyalty_id)}")
       end
 
       def delete(loyalty_id, query = {})
-        @client.delete("/loyalties/#{URI.encode(loyalty_id)}", query)
+        @client.delete("/loyalties/#{ERB::Util.url_encode(loyalty_id)}", query)
         nil
       end
     end
@@ -51,7 +51,7 @@ module Voucherify
       end
 
       def list(loyalty_id, query = {})
-        @client.get("/loyalties/#{URI.encode(loyalty_id)}/earning-rules", query)
+        @client.get("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/earning-rules", query)
       end
 
       def create(loyalty_id, earning_rules)
@@ -59,15 +59,15 @@ module Voucherify
         if earning_rules.is_a? Hash
           payload = [ earning_rules ]
         end
-        @client.post("/loyalties/#{URI.encode(loyalty_id)}/earning-rules", payload.to_json)
+        @client.post("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/earning-rules", payload.to_json)
       end
 
       def update(loyalty_id, earning_rule_id, earning_rule)
-        @client.put("/loyalties/#{URI.encode(loyalty_id)}/earning-rules/#{URI.encode(earning_rule_id)}", earning_rule.to_json)
+        @client.put("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/earning-rules/#{ERB::Util.url_encode(earning_rule_id)}", earning_rule.to_json)
       end
 
       def delete(loyalty_id, earning_rule_id)
-        @client.delete("/loyalties/#{URI.encode(loyalty_id)}/earning-rules/#{URI.encode(earning_rule_id)}")
+        @client.delete("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/earning-rules/#{ERB::Util.url_encode(earning_rule_id)}")
         nil
       end
     end
@@ -80,7 +80,7 @@ module Voucherify
       end
 
       def list(loyalty_id, query = {})
-        @client.get("/loyalties/#{URI.encode(loyalty_id)}/rewards", query)
+        @client.get("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/rewards", query)
       end
 
       def create(loyalty_id, assignments)
@@ -88,15 +88,15 @@ module Voucherify
         if assignments.is_a? Hash
           payload = [ assignments ]
         end
-        @client.post("/loyalties/#{URI.encode(loyalty_id)}/rewards", payload.to_json)
+        @client.post("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/rewards", payload.to_json)
       end
 
       def update(loyalty_id, assignment_id, assignment)
-        @client.put("/loyalties/#{URI.encode(loyalty_id)}/rewards/#{URI.encode(assignment_id)}", assignment.to_json)
+        @client.put("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/rewards/#{ERB::Util.url_encode(assignment_id)}", assignment.to_json)
       end
 
       def delete(loyalty_id, assignment_id)
-        @client.delete("/loyalties/#{URI.encode(loyalty_id)}/rewards/#{URI.encode(assignment_id)}")
+        @client.delete("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/rewards/#{ERB::Util.url_encode(assignment_id)}")
         nil
       end
     end
@@ -108,24 +108,24 @@ module Voucherify
         @client = client
       end
 
-      def list(loyalty_id, query = {}) 
-        @client.get("/loyalties/#{URI.encode(loyalty_id)}/members", query)
+      def list(loyalty_id, query = {})
+        @client.get("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/members", query)
       end
 
-      def add(loyalty_id, member) 
-        @client.post("/loyalties/#{URI.encode(loyalty_id)}/members", member.to_json)
+      def add(loyalty_id, member)
+        @client.post("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/members", member.to_json)
       end
 
-      def get(loyalty_id, member_id) 
-        @client.get("/loyalties/#{URI.encode(loyalty_id)}/members/#{URI.encode(member_id)}")
+      def get(loyalty_id, member_id)
+        @client.get("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/members/#{ERB::Util.url_encode(member_id)}")
       end
 
       def add_balance(loyalty_id, member_id, payload)
-        @client.post("/loyalties/#{URI.encode(loyalty_id)}/members/#{URI.encode(member_id)}/balance", payload.to_json)
+        @client.post("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/members/#{ERB::Util.url_encode(member_id)}/balance", payload.to_json)
       end
 
       def redeem_reward(loyalty_id, member_id, payload)
-        @client.post("/loyalties/#{URI.encode(loyalty_id)}/members/#{URI.encode(member_id)}/redemption", payload.to_json)
+        @client.post("/loyalties/#{ERB::Util.url_encode(loyalty_id)}/members/#{ERB::Util.url_encode(member_id)}/redemption", payload.to_json)
       end
     end
 

--- a/lib/voucherify/service/orders.rb
+++ b/lib/voucherify/service/orders.rb
@@ -14,11 +14,11 @@ module Voucherify
       end
 
       def get(order_id)
-        @client.get("/orders/#{URI.encode(order_id)}")
+        @client.get("/orders/#{ERB::Util.url_encode(order_id)}")
       end
 
       def update(order_id, order)
-        @client.put("/orders/#{URI.encode(order_id)}", order.to_json)
+        @client.put("/orders/#{ERB::Util.url_encode(order_id)}", order.to_json)
       end
 
       def list(query = {})

--- a/lib/voucherify/service/products.rb
+++ b/lib/voucherify/service/products.rb
@@ -14,15 +14,15 @@ module Voucherify
       end
 
       def get(product_id)
-        @client.get("/products/#{URI.encode(product_id)}")
+        @client.get("/products/#{ERB::Util.url_encode(product_id)}")
       end
 
       def update(product)
-        @client.put("/products/#{URI.encode(product['id'] || product[:id])}", product.to_json)
+        @client.put("/products/#{ERB::Util.url_encode(product['id'] || product[:id])}", product.to_json)
       end
 
       def delete(product_id)
-        @client.delete("/products/#{URI.encode(product_id)}")
+        @client.delete("/products/#{ERB::Util.url_encode(product_id)}")
       end
 
       def list(query = {})
@@ -30,23 +30,23 @@ module Voucherify
       end
 
       def create_sku(product_id, sku)
-        @client.post("/products/#{URI.encode(product_id)}/skus", sku.to_json)
+        @client.post("/products/#{ERB::Util.url_encode(product_id)}/skus", sku.to_json)
       end
 
       def get_sku(product_id, sku_id)
-        @client.get("/products/#{URI.encode(product_id)}/skus/#{URI.encode(sku_id)}")
+        @client.get("/products/#{ERB::Util.url_encode(product_id)}/skus/#{ERB::Util.url_encode(sku_id)}")
       end
 
       def update_sku(product_id, sku)
-        @client.put("/products/#{URI.encode(product_id)}/skus/#{URI.encode(sku['id'] || sku[:id])}", sku.to_json)
+        @client.put("/products/#{ERB::Util.url_encode(product_id)}/skus/#{ERB::Util.url_encode(sku['id'] || sku[:id])}", sku.to_json)
       end
 
       def delete_sku(product_id, sku_id)
-        @client.delete("/products/#{URI.encode(product_id)}/skus/#{URI.encode(sku_id)}")
+        @client.delete("/products/#{ERB::Util.url_encode(product_id)}/skus/#{ERB::Util.url_encode(sku_id)}")
       end
 
       def list_skus(product_id)
-        @client.get("/products/#{URI.encode(product_id)}/skus")
+        @client.get("/products/#{ERB::Util.url_encode(product_id)}/skus")
       end
     end
   end

--- a/lib/voucherify/service/promotions.rb
+++ b/lib/voucherify/service/promotions.rb
@@ -30,23 +30,23 @@ module Voucherify
       end
 
       def list(promotion_id)
-        @client.get("/promotions/#{URI.encode(promotion_id)}/tiers")
+        @client.get("/promotions/#{ERB::Util.url_encode(promotion_id)}/tiers")
       end
 
       def create(promotion_id, promotion_tier)
-        @client.post("/promotions/#{URI.encode(promotion_id)}/tiers", promotion_tier.to_json)
+        @client.post("/promotions/#{ERB::Util.url_encode(promotion_id)}/tiers", promotion_tier.to_json)
       end
 
       def redeem(promotions_tier_id, redemption_context)
-        @client.post("/promotions/tiers/#{URI.encode(promotions_tier_id)}/redemption", redemption_context.to_json)
+        @client.post("/promotions/tiers/#{ERB::Util.url_encode(promotions_tier_id)}/redemption", redemption_context.to_json)
       end
 
       def update(promotions_tier)
-        @client.put("/promotions/tiers/#{URI.encode(promotions_tier['id'] || promotions_tier[:id])}", promotions_tier.to_json)
+        @client.put("/promotions/tiers/#{ERB::Util.url_encode(promotions_tier['id'] || promotions_tier[:id])}", promotions_tier.to_json)
       end
 
       def delete(promotions_tier_id)
-        @client.delete("/promotions/tiers/#{URI.encode(promotions_tier_id)}")
+        @client.delete("/promotions/tiers/#{ERB::Util.url_encode(promotions_tier_id)}")
         nil
       end
 

--- a/lib/voucherify/service/redemptions.rb
+++ b/lib/voucherify/service/redemptions.rb
@@ -11,9 +11,9 @@ module Voucherify
 
       def redeem(code, params = {})
         if code.is_a? Hash
-          endpoint = "/promotions/tiers/#{URI.encode(code[:id] || code['id'])}/redemption"
+          endpoint = "/promotions/tiers/#{ERB::Util.url_encode(code[:id] || code['id'])}/redemption"
         else
-          endpoint = "/vouchers/#{URI.encode(code)}/redemption"
+          endpoint = "/vouchers/#{ERB::Util.url_encode(code)}/redemption"
         end
         @client.post(endpoint, params.to_json)
       end
@@ -23,7 +23,7 @@ module Voucherify
       end
 
       def get_for_voucher(code)
-        @client.get("/vouchers/#{URI.encode(code)}/redemption")
+        @client.get("/vouchers/#{ERB::Util.url_encode(code)}/redemption")
       end
 
       def rollback(redemption_id, payload = {})
@@ -31,11 +31,11 @@ module Voucherify
         params = reason ? {:reason => reason} : {}
         payload.delete 'reason'
         payload.delete :reason
-        @client.post("/redemptions/#{URI.encode(redemption_id)}/rollback", payload.to_json, params)
+        @client.post("/redemptions/#{ERB::Util.url_encode(redemption_id)}/rollback", payload.to_json, params)
       end
 
       def get_redemption(redemption_id)
-        @client.get("/redemptions/#{URI.encode(redemption_id)}")
+        @client.get("/redemptions/#{ERB::Util.url_encode(redemption_id)}")
       end
     end
   end

--- a/lib/voucherify/service/rewards.rb
+++ b/lib/voucherify/service/rewards.rb
@@ -18,11 +18,11 @@ module Voucherify
       end
 
       def get(reward_id)
-        @client.get("/rewards/#{URI.encode(reward_id)}")
+        @client.get("/rewards/#{ERB::Util.url_encode(reward_id)}")
       end
 
       def update(reward_id, reward)
-        @client.put("/rewards/#{URI.encode(reward_id)}", reward.to_json)
+        @client.put("/rewards/#{ERB::Util.url_encode(reward_id)}", reward.to_json)
       end
 
       def list(query = {})
@@ -30,7 +30,7 @@ module Voucherify
       end
 
       def delete(reward_id)
-        @client.delete("/rewards/#{URI.encode(reward_id)}")
+        @client.delete("/rewards/#{ERB::Util.url_encode(reward_id)}")
         nil
       end
     end
@@ -43,19 +43,19 @@ module Voucherify
       end
 
       def list(reward_id, query = {})
-        @client.get("/rewards/#{URI.encode(reward_id)}/assignments", query)
+        @client.get("/rewards/#{ERB::Util.url_encode(reward_id)}/assignments", query)
       end
 
       def create(reward_id, assignment)
-        @client.post("/rewards/#{URI.encode(reward_id)}/assignments", assignment.to_json)
+        @client.post("/rewards/#{ERB::Util.url_encode(reward_id)}/assignments", assignment.to_json)
       end
 
       def update(reward_id, assignment_id, assignment)
-        @client.put("/rewards/#{URI.encode(reward_id)}/assignments/#{URI.encode(assignment_id)}", assignment.to_json)
+        @client.put("/rewards/#{ERB::Util.url_encode(reward_id)}/assignments/#{ERB::Util.url_encode(assignment_id)}", assignment.to_json)
       end
 
       def delete(reward_id, assignment_id)
-        @client.delete("/rewards/#{URI.encode(reward_id)}/assignments/#{URI.encode(assignment_id)}")
+        @client.delete("/rewards/#{ERB::Util.url_encode(reward_id)}/assignments/#{ERB::Util.url_encode(assignment_id)}")
         nil
       end
     end

--- a/lib/voucherify/service/segments.rb
+++ b/lib/voucherify/service/segments.rb
@@ -14,11 +14,11 @@ module Voucherify
       end
 
       def get(id)
-        @client.get("/segments/#{URI.encode(id)}")
+        @client.get("/segments/#{ERB::Util.url_encode(id)}")
       end
 
       def delete(id)
-        @client.delete("/segments/#{URI.encode(id)}")
+        @client.delete("/segments/#{ERB::Util.url_encode(id)}")
       end
     end
   end

--- a/lib/voucherify/service/validation_rules.rb
+++ b/lib/voucherify/service/validation_rules.rb
@@ -22,27 +22,27 @@ module Voucherify
       end
 
       def get(id)
-        @client.get("/validation-rules/#{URI.encode(id)}")
+        @client.get("/validation-rules/#{ERB::Util.url_encode(id)}")
       end
 
       def update(validation_rules)
-        @client.put("/validation-rules/#{URI.encode(validation_rules['id'] || validation_rules[:id])}", validation_rules.to_json)
+        @client.put("/validation-rules/#{ERB::Util.url_encode(validation_rules['id'] || validation_rules[:id])}", validation_rules.to_json)
       end
 
       def delete(id)
-        @client.delete("/validation-rules/#{URI.encode(id)}")
+        @client.delete("/validation-rules/#{ERB::Util.url_encode(id)}")
       end
 
       def createAssignment(id, assignment)
-        @client.post("/validation-rules/#{URI.encode(id)}/assignments", assignment.to_json)
+        @client.post("/validation-rules/#{ERB::Util.url_encode(id)}/assignments", assignment.to_json)
       end
 
       def deleteAssignment(rule_id, assignment_id)
-        @client.delete("/validation-rules/#{URI.encode(rule_id)}/assignments/#{URI.encode(assignment_id)}")
+        @client.delete("/validation-rules/#{ERB::Util.url_encode(rule_id)}/assignments/#{ERB::Util.url_encode(assignment_id)}")
       end
 
       def listAssignments(id, query)
-        @client.get("/validation-rules/#{URI.encode(id)}/assignments", query)
+        @client.get("/validation-rules/#{ERB::Util.url_encode(id)}/assignments", query)
       end
     end
 
@@ -54,15 +54,15 @@ module Voucherify
       end
 
       def create(rule_id, assignment)
-        @client.post("/validation-rules/#{URI.encode(rule_id)}/assignments", assignment.to_json)
+        @client.post("/validation-rules/#{ERB::Util.url_encode(rule_id)}/assignments", assignment.to_json)
       end
 
       def delete(rule_id, assignment_id)
-        @client.delete("/validation-rules/#{URI.encode(rule_id)}/assignments/#{URI.encode(assignment_id)}")
+        @client.delete("/validation-rules/#{ERB::Util.url_encode(rule_id)}/assignments/#{ERB::Util.url_encode(assignment_id)}")
       end
 
       def list(rule_id, query)
-        @client.get("/validation-rules/#{URI.encode(rule_id)}/assignments", query)
+        @client.get("/validation-rules/#{ERB::Util.url_encode(rule_id)}/assignments", query)
       end
     end
   end

--- a/lib/voucherify/service/validations.rb
+++ b/lib/voucherify/service/validations.rb
@@ -10,7 +10,7 @@ module Voucherify
       end
 
       def validate_voucher(code, context = {})
-        @client.post("/vouchers/#{URI.encode(code)}/validate", context.to_json)
+        @client.post("/vouchers/#{ERB::Util.url_encode(code)}/validate", context.to_json)
       end
 
       def validate(code, context = {})

--- a/lib/voucherify/service/vouchers.rb
+++ b/lib/voucherify/service/vouchers.rb
@@ -11,16 +11,16 @@ module Voucherify
 
       def create(code, options = {})
         url = '/vouchers'
-        url += '/' + URI.encode(code) if code
+        url += '/' + ERB::Util.url_encode(code) if code
         @client.post(url, options.to_json)
       end
 
       def get(code)
-        @client.get("/vouchers/#{URI.encode(code)}")
+        @client.get("/vouchers/#{ERB::Util.url_encode(code)}")
       end
 
       def update(voucher_update)
-        @client.put("/vouchers/#{URI.encode(voucher_update['code'] || voucher_update[:code])}", voucher_update.to_json)
+        @client.put("/vouchers/#{ERB::Util.url_encode(voucher_update['code'] || voucher_update[:code])}", voucher_update.to_json)
       end
 
       def list(query)
@@ -28,17 +28,17 @@ module Voucherify
       end
 
       def enable(code)
-        @client.post("/vouchers/#{URI.encode(code)}/enable", nil)
+        @client.post("/vouchers/#{ERB::Util.url_encode(code)}/enable", nil)
         nil
       end
 
       def disable(code)
-        @client.post("/vouchers/#{URI.encode(code)}/disable", nil)
+        @client.post("/vouchers/#{ERB::Util.url_encode(code)}/disable", nil)
         nil
       end
 
       def delete(code, params = {})
-        @client.delete("/vouchers/#{URI.encode(code)}", {:force => (!!(params['force'] || params[:force])).to_s})
+        @client.delete("/vouchers/#{ERB::Util.url_encode(code)}", {:force => (!!(params['force'] || params[:force])).to_s})
         nil
       end
 
@@ -47,7 +47,7 @@ module Voucherify
       end
 
       def add_balance(code, balance)
-        @client.post("/vouchers/#{URI.encode(code)}/balance", balance.to_json)
+        @client.post("/vouchers/#{ERB::Util.url_encode(code)}/balance", balance.to_json)
       end
     end
   end

--- a/spec/promotions_spec.rb
+++ b/spec/promotions_spec.rb
@@ -144,7 +144,7 @@ describe 'Promotions API' do
   end
 
   it 'should list promotion\'s tiers' do
-    stub_request(:get, "#{api_url}/promotions/#{URI.encode(promotion_campaign_id)}/tiers")
+    stub_request(:get, "#{api_url}/promotions/#{ERB::Util.url_encode(promotion_campaign_id)}/tiers")
         .with(body: nil, headers: headers)
         .to_return(:status => 200, :body => promotions_tiers.to_json, :headers => {})
 
@@ -152,7 +152,7 @@ describe 'Promotions API' do
   end
 
   it 'should create promotion\'s tier' do
-    stub_request(:post, "#{api_url}/promotions/#{URI.encode(promotion_campaign_id)}/tiers")
+    stub_request(:post, "#{api_url}/promotions/#{ERB::Util.url_encode(promotion_campaign_id)}/tiers")
         .with(body: promotions_tier, headers: headers)
         .to_return(:status => 200, :body => promotions_tier.to_json, :headers => {})
 
@@ -162,7 +162,7 @@ describe 'Promotions API' do
   it 'should update promotion\'s tier' do
     promotions_tier_w_id = promotions_tier.merge({id: promotions_tier_id})
 
-    stub_request(:put, "#{api_url}/promotions/tiers/#{URI.encode(promotions_tier_id)}")
+    stub_request(:put, "#{api_url}/promotions/tiers/#{ERB::Util.url_encode(promotions_tier_id)}")
         .with(body: promotions_tier_w_id, headers: headers)
         .to_return(:status => 200, :body => promotions_tier_w_id.to_json, :headers => {})
 
@@ -170,7 +170,7 @@ describe 'Promotions API' do
   end
 
   it 'should delete promotion\'s tier' do
-    stub_request(:delete, "#{api_url}/promotions/tiers/#{URI.encode(promotions_tier_id)}")
+    stub_request(:delete, "#{api_url}/promotions/tiers/#{ERB::Util.url_encode(promotions_tier_id)}")
         .with(body: nil, headers: headers)
         .to_return(:status => 200, :body => nil, :headers => {})
 


### PR DESCRIPTION
Proposed fix for Issue #50 

### Why?
URI.encode and URI.escape were deprecated in Ruby 1.9.3. 

### Changes
Replaces calls to `URI.encode` with `ERB::Util.url_encode`.

### Notes
`ERB::Util.url_encode` seems to be preferred over the suggested `CGI.escape` as the latter replaces spaces with a + symbol. See discussion on [SO](https://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape) and the [docs for ERB::Util](https://docs.ruby-lang.org/en/3.0.0/ERB/Util.html) for more information.