### PR TITLE
Look up `source_id` if `id` is absent on `Products#update`

### DIFF
--- a/lib/voucherify/service/products.rb
+++ b/lib/voucherify/service/products.rb
@@ -18,7 +18,7 @@ module Voucherify
       end
 
       def update(product)
-        @client.put("/products/#{ERB::Util.url_encode(product['id'] || product[:id])}", product.to_json)
+        @client.put("/products/#{ERB::Util.url_encode(product['id'] || product[:id] || product['source_id'] || product[:source_id])}", product.to_json)
       end
 
       def delete(product_id)

--- a/lib/voucherify/version.rb
+++ b/lib/voucherify/version.rb
@@ -1,3 +1,3 @@
 module Voucherify
-  VERSION = '4.1.0'
+  VERSION = '4.2.0'
 end

--- a/spec/products_spec.rb
+++ b/spec/products_spec.rb
@@ -53,6 +53,16 @@ describe 'Products API' do
     voucherify.products.update(product)
   end
 
+  it 'should update product with source id' do
+    product.delete(:id)
+
+    stub_request(:put, "https://api.voucherify.io/v1/products/#{product[:source_id]}")
+        .with(body: product.to_json, headers: headers)
+        .to_return(:status => 200, :body => product.to_json, :headers => {})
+
+    voucherify.products.update(product)
+  end
+
   it 'should delete product' do
     stub_request(:delete, "https://api.voucherify.io/v1/products/#{product[:id]}")
         .with(body: {}, headers: headers)


### PR DESCRIPTION
According to the [docs](https://docs.voucherify.io/reference/update-product), both the product ID and source ID are acceptable as path parameters in a `PUT /products/:product_id` request.

As such, it would be nice if `Voucherify::Service::Products#update` checked for `source_id` when an `id` key is absent, as this would add clarity to the call site.

For instance, the following call should be possible:

```ruby
voucherify.products.update({
  source_id: 'my source id',
  # remaining fields
})
```