### PR TITLE
v8.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 
 RUN gem build VoucherifySdk.gemspec
-RUN gem install voucherify-8.0.0.gem
+RUN gem install voucherify-8.0.1.gem
 RUN gem install dotenv
 RUN gem install rspec
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Remember that this SDK is auto generated (except of the tests) so changes made h
 
 ## 📅 Changelog
 
+- **2024-11-04** - `8.0.1`
+  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded
 - **2024-10-28** - `8.0.0`
   - Added missing `enums` in few filters models
   - !!! BREAKING CHANGES !!!

--- a/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ClientValidationsValidateResponseBodyRedeemablesItem.md
@@ -13,4 +13,6 @@
 | **result** | [**ClientValidationsValidateResponseBodyRedeemablesItemResult**](ClientValidationsValidateResponseBodyRedeemablesItemResult.md) |  | [optional] |
 | **metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] |
 | **categories** | [**Array&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  | [optional] |
+| **campaign_name** | **String** | Campaign name | [optional] |
+| **campaign_id** | **String** | Unique campaign ID assigned by Voucherify. | [optional] |
 

--- a/docs/ValidationsRedeemableInapplicable.md
+++ b/docs/ValidationsRedeemableInapplicable.md
@@ -10,4 +10,6 @@
 | **result** | [**ValidationsRedeemableInapplicableResult**](ValidationsRedeemableInapplicableResult.md) |  | [optional] |
 | **metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] |
 | **categories** | [**Array&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  | [optional] |
+| **campaign_name** | **String** | Campaign name | [optional] |
+| **campaign_id** | **String** | Unique campaign ID assigned by Voucherify. | [optional] |
 

--- a/docs/ValidationsRedeemableSkipped.md
+++ b/docs/ValidationsRedeemableSkipped.md
@@ -10,4 +10,6 @@
 | **result** | [**ValidationsRedeemableSkippedResult**](ValidationsRedeemableSkippedResult.md) |  | [optional] |
 | **metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] |
 | **categories** | [**Array&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  | [optional] |
+| **campaign_name** | **String** | Campaign name | [optional] |
+| **campaign_id** | **String** | Unique campaign ID assigned by Voucherify. | [optional] |
 

--- a/docs/ValidationsValidateResponseBodyRedeemablesItem.md
+++ b/docs/ValidationsValidateResponseBodyRedeemablesItem.md
@@ -13,4 +13,6 @@
 | **result** | [**ValidationsValidateResponseBodyRedeemablesItemResult**](ValidationsValidateResponseBodyRedeemablesItemResult.md) |  | [optional] |
 | **metadata** | **Object** | The metadata object stores all custom attributes in the form of key/value pairs assigned to the redeemable. | [optional] |
 | **categories** | [**Array&lt;CategoryWithStackingRulesType&gt;**](CategoryWithStackingRulesType.md) |  | [optional] |
+| **campaign_name** | **String** | Campaign name | [optional] |
+| **campaign_id** | **String** | Unique campaign ID assigned by Voucherify. | [optional] |
 

--- a/lib/VoucherifySdk/models/client_validations_validate_response_body_redeemables_item.rb
+++ b/lib/VoucherifySdk/models/client_validations_validate_response_body_redeemables_item.rb
@@ -36,6 +36,12 @@ module VoucherifySdk
 
     attr_accessor :categories
 
+    # Campaign name
+    attr_accessor :campaign_name
+
+    # Unique campaign ID assigned by Voucherify.
+    attr_accessor :campaign_id
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -69,7 +75,9 @@ module VoucherifySdk
         :'inapplicable_to' => :'inapplicable_to',
         :'result' => :'result',
         :'metadata' => :'metadata',
-        :'categories' => :'categories'
+        :'categories' => :'categories',
+        :'campaign_name' => :'campaign_name',
+        :'campaign_id' => :'campaign_id'
       }
     end
 
@@ -89,7 +97,9 @@ module VoucherifySdk
         :'inapplicable_to' => :'InapplicableToResultList',
         :'result' => :'ClientValidationsValidateResponseBodyRedeemablesItemResult',
         :'metadata' => :'Object',
-        :'categories' => :'Array<CategoryWithStackingRulesType>'
+        :'categories' => :'Array<CategoryWithStackingRulesType>',
+        :'campaign_name' => :'String',
+        :'campaign_id' => :'String'
       }
     end
 
@@ -99,7 +109,9 @@ module VoucherifySdk
         :'id',
         :'object',
         :'metadata',
-        :'categories'
+        :'categories',
+        :'campaign_name',
+        :'campaign_id'
       ])
     end
 
@@ -148,6 +160,14 @@ module VoucherifySdk
           self.categories = value
         end
       end
+
+      if attributes.key?(:'campaign_name')
+        self.campaign_name = attributes[:'campaign_name']
+      end
+
+      if attributes.key?(:'campaign_id')
+        self.campaign_id = attributes[:'campaign_id']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -182,7 +202,9 @@ module VoucherifySdk
           inapplicable_to == o.inapplicable_to &&
           result == o.result &&
           metadata == o.metadata &&
-          categories == o.categories
+          categories == o.categories &&
+          campaign_name == o.campaign_name &&
+          campaign_id == o.campaign_id
     end
 
     # @see the `==` method
@@ -194,7 +216,7 @@ module VoucherifySdk
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [status, id, object, order, applicable_to, inapplicable_to, result, metadata, categories].hash
+      [status, id, object, order, applicable_to, inapplicable_to, result, metadata, categories, campaign_name, campaign_id].hash
     end
 
     # Builds the object from hash

--- a/lib/VoucherifySdk/models/validations_redeemable_inapplicable.rb
+++ b/lib/VoucherifySdk/models/validations_redeemable_inapplicable.rb
@@ -31,6 +31,12 @@ module VoucherifySdk
 
     attr_accessor :categories
 
+    # Campaign name
+    attr_accessor :campaign_name
+
+    # Unique campaign ID assigned by Voucherify.
+    attr_accessor :campaign_id
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -61,7 +67,9 @@ module VoucherifySdk
         :'object' => :'object',
         :'result' => :'result',
         :'metadata' => :'metadata',
-        :'categories' => :'categories'
+        :'categories' => :'categories',
+        :'campaign_name' => :'campaign_name',
+        :'campaign_id' => :'campaign_id'
       }
     end
 
@@ -78,7 +86,9 @@ module VoucherifySdk
         :'object' => :'String',
         :'result' => :'ValidationsRedeemableInapplicableResult',
         :'metadata' => :'Object',
-        :'categories' => :'Array<CategoryWithStackingRulesType>'
+        :'categories' => :'Array<CategoryWithStackingRulesType>',
+        :'campaign_name' => :'String',
+        :'campaign_id' => :'String'
       }
     end
 
@@ -90,7 +100,9 @@ module VoucherifySdk
         :'object',
         :'result',
         :'metadata',
-        :'categories'
+        :'categories',
+        :'campaign_name',
+        :'campaign_id'
       ])
     end
 
@@ -129,6 +141,14 @@ module VoucherifySdk
           self.categories = value
         end
       end
+
+      if attributes.key?(:'campaign_name')
+        self.campaign_name = attributes[:'campaign_name']
+      end
+
+      if attributes.key?(:'campaign_id')
+        self.campaign_id = attributes[:'campaign_id']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -160,7 +180,9 @@ module VoucherifySdk
           object == o.object &&
           result == o.result &&
           metadata == o.metadata &&
-          categories == o.categories
+          categories == o.categories &&
+          campaign_name == o.campaign_name &&
+          campaign_id == o.campaign_id
     end
 
     # @see the `==` method
@@ -172,7 +194,7 @@ module VoucherifySdk
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [status, id, object, result, metadata, categories].hash
+      [status, id, object, result, metadata, categories, campaign_name, campaign_id].hash
     end
 
     # Builds the object from hash

--- a/lib/VoucherifySdk/models/validations_redeemable_skipped.rb
+++ b/lib/VoucherifySdk/models/validations_redeemable_skipped.rb
@@ -31,6 +31,12 @@ module VoucherifySdk
 
     attr_accessor :categories
 
+    # Campaign name
+    attr_accessor :campaign_name
+
+    # Unique campaign ID assigned by Voucherify.
+    attr_accessor :campaign_id
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -61,7 +67,9 @@ module VoucherifySdk
         :'object' => :'object',
         :'result' => :'result',
         :'metadata' => :'metadata',
-        :'categories' => :'categories'
+        :'categories' => :'categories',
+        :'campaign_name' => :'campaign_name',
+        :'campaign_id' => :'campaign_id'
       }
     end
 
@@ -78,7 +86,9 @@ module VoucherifySdk
         :'object' => :'String',
         :'result' => :'ValidationsRedeemableSkippedResult',
         :'metadata' => :'Object',
-        :'categories' => :'Array<CategoryWithStackingRulesType>'
+        :'categories' => :'Array<CategoryWithStackingRulesType>',
+        :'campaign_name' => :'String',
+        :'campaign_id' => :'String'
       }
     end
 
@@ -90,7 +100,9 @@ module VoucherifySdk
         :'object',
         :'result',
         :'metadata',
-        :'categories'
+        :'categories',
+        :'campaign_name',
+        :'campaign_id'
       ])
     end
 
@@ -129,6 +141,14 @@ module VoucherifySdk
           self.categories = value
         end
       end
+
+      if attributes.key?(:'campaign_name')
+        self.campaign_name = attributes[:'campaign_name']
+      end
+
+      if attributes.key?(:'campaign_id')
+        self.campaign_id = attributes[:'campaign_id']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -160,7 +180,9 @@ module VoucherifySdk
           object == o.object &&
           result == o.result &&
           metadata == o.metadata &&
-          categories == o.categories
+          categories == o.categories &&
+          campaign_name == o.campaign_name &&
+          campaign_id == o.campaign_id
     end
 
     # @see the `==` method
@@ -172,7 +194,7 @@ module VoucherifySdk
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [status, id, object, result, metadata, categories].hash
+      [status, id, object, result, metadata, categories, campaign_name, campaign_id].hash
     end
 
     # Builds the object from hash

--- a/lib/VoucherifySdk/models/validations_validate_response_body_redeemables_item.rb
+++ b/lib/VoucherifySdk/models/validations_validate_response_body_redeemables_item.rb
@@ -36,6 +36,12 @@ module VoucherifySdk
 
     attr_accessor :categories
 
+    # Campaign name
+    attr_accessor :campaign_name
+
+    # Unique campaign ID assigned by Voucherify.
+    attr_accessor :campaign_id
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -69,7 +75,9 @@ module VoucherifySdk
         :'inapplicable_to' => :'inapplicable_to',
         :'result' => :'result',
         :'metadata' => :'metadata',
-        :'categories' => :'categories'
+        :'categories' => :'categories',
+        :'campaign_name' => :'campaign_name',
+        :'campaign_id' => :'campaign_id'
       }
     end
 
@@ -89,7 +97,9 @@ module VoucherifySdk
         :'inapplicable_to' => :'InapplicableToResultList',
         :'result' => :'ValidationsValidateResponseBodyRedeemablesItemResult',
         :'metadata' => :'Object',
-        :'categories' => :'Array<CategoryWithStackingRulesType>'
+        :'categories' => :'Array<CategoryWithStackingRulesType>',
+        :'campaign_name' => :'String',
+        :'campaign_id' => :'String'
       }
     end
 
@@ -99,7 +109,9 @@ module VoucherifySdk
         :'id',
         :'object',
         :'metadata',
-        :'categories'
+        :'categories',
+        :'campaign_name',
+        :'campaign_id'
       ])
     end
 
@@ -148,6 +160,14 @@ module VoucherifySdk
           self.categories = value
         end
       end
+
+      if attributes.key?(:'campaign_name')
+        self.campaign_name = attributes[:'campaign_name']
+      end
+
+      if attributes.key?(:'campaign_id')
+        self.campaign_id = attributes[:'campaign_id']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -182,7 +202,9 @@ module VoucherifySdk
           inapplicable_to == o.inapplicable_to &&
           result == o.result &&
           metadata == o.metadata &&
-          categories == o.categories
+          categories == o.categories &&
+          campaign_name == o.campaign_name &&
+          campaign_id == o.campaign_id
     end
 
     # @see the `==` method
@@ -194,7 +216,7 @@ module VoucherifySdk
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [status, id, object, order, applicable_to, inapplicable_to, result, metadata, categories].hash
+      [status, id, object, order, applicable_to, inapplicable_to, result, metadata, categories, campaign_name, campaign_id].hash
     end
 
     # Builds the object from hash

--- a/lib/VoucherifySdk/version.rb
+++ b/lib/VoucherifySdk/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 7.0.1
 =end
 
 module VoucherifySdk
-  VERSION = '8.0.0'
+  VERSION = '8.0.1'
 end


### PR DESCRIPTION
- **2024-11-04** - `8.0.1`
  - Added support for returning `campaign_id` and `campaign_name` in stackable validation endpoint, when `redeemable` option is expanded